### PR TITLE
add: Spring Security 6부터 지향하는 Lambda DSL 방식에 맞춰 Spring Security Config 클래스 작성

### DIFF
--- a/src/main/java/com/jiho/anniehands/security/AnniehandsSecurityConfig.java
+++ b/src/main/java/com/jiho/anniehands/security/AnniehandsSecurityConfig.java
@@ -1,0 +1,47 @@
+package com.jiho.anniehands.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+@EnableMethodSecurity(securedEnabled = true)
+public class AnniehandsSecurityConfig {
+    /*
+    * Spring Security 6부터는 '.and()'메서드를 제거하고 Lambda DSL을 강화하는 방식으로 업데이트되어, Deprecated된 부분이 있다.
+    * Lambda DSL의 장점: 기존에 사용하던 '.and()' 메서드는 서로 무관한 요소까지 체이닝 됐기 때문에 코드의 가독성을 저하시켰다.
+    * 때문에 람다 메서드 호출 후에는 HttpSecurity 인스턴스가 자동으로 반환되어 '.and()'메서드 없이도 구성이 가능해졌다.
+    * 이는 시큐리티의 설정 구성을 관련 메서드들끼리 모듈화(그룹화)하여 보다 직관적이고 간결하게 설정 정보를 알 수 있다.
+    * */
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+
+        // csrf 비활성화
+        http.csrf(AbstractHttpConfigurer::disable)
+                // 로그인 관련 설정
+                .formLogin(formLoginConfigurer-> formLoginConfigurer
+                        .loginPage("/login")
+                        .usernameParameter("id")
+                        .passwordParameter("password")
+                        .loginProcessingUrl("/login")
+                        .defaultSuccessUrl("/")
+                        .failureUrl("/login?error=fail"))
+                // 로그아웃 관련 설정
+                .logout(logoutConfigurer -> logoutConfigurer
+                        .logoutUrl("/logout")
+                        .logoutSuccessUrl("/")
+                        .invalidateHttpSession(true))
+                // 인증인가 관련 설정
+                .exceptionHandling(exceptionHandlingConfigurer -> exceptionHandlingConfigurer
+                        .authenticationEntryPoint((request, response, authException) -> response.sendRedirect("/login?error=noauth"))
+                        .accessDeniedHandler((request, response, authException) -> response.sendRedirect("/login?error=denied")));
+
+        return http.build();
+    }
+}
+

--- a/src/main/resources/templates/common/navbar.html
+++ b/src/main/resources/templates/common/navbar.html
@@ -16,10 +16,10 @@
                 <div class="collapse navbar-collapse" id="navbarNavDropdown">
                     <ul class="navbar-nav ms-auto">
                         <li class="nav-item">
-                            <a class="nav-link" href="#">로그인</a>
+                            <a class="nav-link" th:href="@{/login}">로그인</a>
                         </li>
                         <li class="nav-item">
-                            <a class="nav-link" href="#">회원가입</a>
+                            <a class="nav-link" th:href="@{/singup}">회원가입</a>
                         </li>
                         <li class="nav-item">
                             <a class="nav-link" href="#">장바구니</a>


### PR DESCRIPTION
## ✅ PR내용
- **Spring Security 6**부터 지향하는 **Lambda DSL** 방식에 맞춰 Spring Security Config 클래스르 작성했다.
  - `AnniehandsSecurityConfig.class`

## 🔍참고사항
- Spring Security 6부터는 **`.and()`메서드를 제거**하고 **Lambda DSL을 강화**하는 방식으로 업데이트되어, Deprecated된 부분이 있다.
  - **Lambda DSL의 장점**: 기존에 사용하던 `.and()` 메서드는 서로 무관한 요소까지 체이닝 됐기 때문에 코드의 가독성을 저하시켰다.
  - 때문에 Spring Security 6 이후로는 **람다 메서드 호출 후에는 `HttpSecurity` 인스턴스가 자동으로 반환**되어 `.and()` 메서드 없이도 구성이 가능해졌다.
  - **이를 통해 시큐리티의 설정 구성을 관련 메서드들끼리 모듈화(그룹화)하여 보다 직관적이고 간결하게 설정 정보를 알 수 있다.**

- `navber.html`에서 로그인, 회원가입 경로 추가
   