### PR TITLE
add: CI/CD 구축을 위한 appspec.yml, deploy.sh 파일 생성 및 RedisConfig 비밀번호 설정

### DIFF
--- a/appspec.yml
+++ b/appspec.yml
@@ -1,0 +1,17 @@
+version: 0.0
+os: linux
+
+files:
+  - source: /
+    destination: /home/ubuntu/anniehands
+    overwrite: yes
+file_exists_behavior: OVERWRITE
+permissions:
+  - object: /home/ubuntu/anniehands/
+    owner: ubuntu
+    group: ubuntu
+hooks:
+  AfterInstall:
+    - location: scripts/deploy.sh
+      timeout: 60
+      runas: ubuntu

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+REPOSITORY=/home/ubuntu/anniehands
+cd $REPOSITORY
+
+APP_NAME=anniehands
+JAR_NAME=$(ls $REPOSITORY/build/libs/ | grep 'SNAPSHOT.jar' | tail -n 1)
+JAR_PATH=$REPOSITORY/build/libs/$JAR_NAME
+
+CURRENT_PID=$(pgrep -f $APP_NAME)
+
+if [ -z $CURRENT_PID ]
+then
+  echo "> 종료할 애플리케이션이 없습니다."
+else
+  echo "> kill -15 $CURRENT_PID"
+  kill -15 $CURRENT_PID
+  sleep 5
+  echo "> 종료 완료"
+fi
+
+echo "> Deploy - $JAR_PATH "
+nohup java -jar $JAR_PATH > /dev/null 2> /dev/null < /dev/null &

--- a/src/main/java/com/jiho/anniehands/common/config/RedisConfig.java
+++ b/src/main/java/com/jiho/anniehands/common/config/RedisConfig.java
@@ -5,6 +5,7 @@ import org.springframework.boot.autoconfigure.data.redis.RedisProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
@@ -19,7 +20,11 @@ public class RedisConfig {
 
     @Bean
     public RedisConnectionFactory redisConnectionFactory() {
-        return new LettuceConnectionFactory(redisProperties.getHost(), redisProperties.getPort());
+        RedisStandaloneConfiguration config = new RedisStandaloneConfiguration();
+        config.setHostName(redisProperties.getHost());
+        config.setPort(redisProperties.getPort());
+        config.setPassword(redisProperties.getPassword()); // 비밀번호 설정
+        return new LettuceConnectionFactory(config);
     }
 
     @Bean


### PR DESCRIPTION
## ✅ PR내용
- CI/CD 구축을 위한 `appspec.yml`, `deploy.sh` 파일을 생성했다.
- EC2 안 Redis Server에서 사용될 `RedisConfig` 비밀번호 설정
- GitHub Action Workflow & Secrets Repository 정의
## 🔍참고사항
- **CI/CD 구축을 위해 GitHub Action과 AWS 서비스를 이용했다.**
1. main브랜치의 상태 변화에 따라 수행할 **GitHub Action**의 **Workflow**를 정의
2. 정의를 따라 빌드 및 테스트 완료한 앱파일을 **zip으로 생성한 뒤 S3 버킷에 업로드** 
3. **CodeDeploy에게 S3에 업로드 된 파일을 배포**하도록 명령
4. 명령에 따라 **EC2에 신규 jar파일 배포** 수행

- 민감한 정보가 담겨 `.gitignore`처리한 yml파일, AWS 접근 권한 데이터 등을 Action의 Secrets에 저장
  - **`.gitignore`처리한 yml파일**➡️ Secrets의 yml내용을 참조하여 Workflow가 수행될 때, yml파일을 직접 생성하도록 정의
  -  **AWS 접근 권한 데이터**➡️ Secrets의 AWS 서비스의 key 값을 참조하여 Workflow에서 AWS 서비스 접근 수행
