### PR TITLE
36 feat 카테고리 별 상품 리스트 출력 구현

### DIFF
--- a/src/main/java/com/jiho/anniehands/address/Address.java
+++ b/src/main/java/com/jiho/anniehands/address/Address.java
@@ -33,7 +33,7 @@ public class Address {
     @Column(name = "is_default", nullable = false)
     private boolean isDefault;
 
-    // 연관 관계 매핑 (User 엔티티가 있다고 가정)
+    // 연관 관계 매핑
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_no")
     private User user;

--- a/src/main/java/com/jiho/anniehands/category/Category.java
+++ b/src/main/java/com/jiho/anniehands/category/Category.java
@@ -1,8 +1,10 @@
 package com.jiho.anniehands.category;
 
+import com.jiho.anniehands.product.Product;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Entity
@@ -17,14 +19,22 @@ public class Category {
     @Column(nullable = false, length = 45)
     private String name;
 
+    // 상품 목록과 관계 매핑
+    // mappedBy는 연관관계의 주인이 아닌 쪽에서 사용되며, 연관관계의 주인을 지정할 때 사용한다.
+    //  연관관계의 주인은 외래키를 관리하는 쪽(category)이다.
+    @OneToMany(mappedBy = "category")
+    private List<Product> products = new ArrayList<>();
+
     // 부모 카테고리와의 관계 매핑
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "parent_category_id")
+    @JoinColumn(name = "parent_category_no")
     private Category parentCategory;
 
     // 자식 카테고리 리스트를 위한 관계 매핑
+    // mappedBy는 연관관계의 주인이 아닌 쪽에서 사용되며, 연관관계의 주인을 지정할 때 사용한다.
+    //  연관관계의 주인은 외래키를 관리하는 쪽(parentCategory)이다.
     @OneToMany(mappedBy = "parentCategory")
-    private List<Category> childCategories;
+    private List<Category> childCategories = new ArrayList<>();
 
     @Builder
     public Category(Integer no, String name, Category parentCategory, List<Category> childCategories) {

--- a/src/main/java/com/jiho/anniehands/category/CategoryDto.java
+++ b/src/main/java/com/jiho/anniehands/category/CategoryDto.java
@@ -1,0 +1,21 @@
+package com.jiho.anniehands.category;
+
+import lombok.*;
+
+@Getter
+@ToString
+@Builder
+public class CategoryDto {
+
+    private Integer no;
+    private String name;
+    private Integer parent;
+
+    public static CategoryDto createDto(Category category) {
+        return CategoryDto.builder()
+                .no(category.getNo())
+                .name(category.getName())
+                .parent(category.getParentCategory().getNo())
+                .build();
+    }
+}

--- a/src/main/java/com/jiho/anniehands/category/CategoryRepository.java
+++ b/src/main/java/com/jiho/anniehands/category/CategoryRepository.java
@@ -17,7 +17,8 @@ public interface CategoryRepository extends JpaRepository<Category,Integer> {
     // 상위 카테고리 번호를 기반으로 하위 카테고리 목록을 조회하는 메서드
     List<Category> findByParentCategory_No(Integer parentNo);
 
-    @Query("SELECT c FROM Category c LEFT JOIN c.products p ON p.isEnabled = true WHERE c.no = :categoryNo OR c.parentCategory.no = :categoryNo")
+    @Query("SELECT c FROM Category c LEFT JOIN c.parentCategory p WHERE c.no = :categoryNo OR p.no = :categoryNo")
     List<Category> findCategoriesAndSubcategoriesByNo(Integer categoryNo);
+
 
 }

--- a/src/main/java/com/jiho/anniehands/category/CategoryRepository.java
+++ b/src/main/java/com/jiho/anniehands/category/CategoryRepository.java
@@ -1,0 +1,23 @@
+package com.jiho.anniehands.category;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface CategoryRepository extends JpaRepository<Category,Integer> {
+
+    Optional<Category> findByNo(Integer No);
+
+    List<Category> findAll();
+
+    // 상위 카테고리 번호를 기반으로 하위 카테고리 목록을 조회하는 메서드
+    List<Category> findByParentCategory_No(Integer parentNo);
+
+    @Query("SELECT c FROM Category c LEFT JOIN c.products p ON p.isEnabled = true WHERE c.no = :categoryNo OR c.parentCategory.no = :categoryNo")
+    List<Category> findCategoriesAndSubcategoriesByNo(Integer categoryNo);
+
+}

--- a/src/main/java/com/jiho/anniehands/category/CategoryResult.java
+++ b/src/main/java/com/jiho/anniehands/category/CategoryResult.java
@@ -1,0 +1,26 @@
+package com.jiho.anniehands.category;
+
+import com.jiho.anniehands.product.ProductDto;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@ToString
+public class CategoryResult {
+    private Integer no;
+    private String name;
+    private Integer parent;
+    private List<CategoryDto> children;
+    private Page<ProductDto> products;
+
+    public void setChildren(List<CategoryDto> children) {
+        this.children = children;
+    }
+}

--- a/src/main/java/com/jiho/anniehands/category/CategoryService.java
+++ b/src/main/java/com/jiho/anniehands/category/CategoryService.java
@@ -1,0 +1,73 @@
+package com.jiho.anniehands.category;
+
+import com.jiho.anniehands.common.exception.CustomErrorCode;
+import com.jiho.anniehands.common.exception.PageException;
+import com.jiho.anniehands.product.ProductDto;
+import com.jiho.anniehands.product.ProductRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CategoryService {
+
+    private final CategoryRepository categoryRepository;
+    private final ProductRepository productRepository;
+
+    public Optional<Category> findByNo(Integer categoryNo) {
+        return categoryRepository.findByNo(categoryNo);
+    }
+
+    public List<Category> findAll() {
+        return categoryRepository.findAll();
+    }
+
+    @Transactional
+    public CategoryResult getCategoryInfo(Integer categoryNo, Pageable pageable) {
+        // 2. 카테고리와 상품은 양방향 매핑으로 카테고리로 번호로 상품 조회가 가능하다.
+        // DB접근의 횟수가 적어짐 상대적으로 수행처리가 속도가 빠름
+        List<Category> categories = categoryRepository.findCategoriesAndSubcategoriesByNo(categoryNo);
+        if (categories.isEmpty()) {
+            throw new PageException(CustomErrorCode.NOT_FOUND);
+        }
+        Category currentCategory = categories.stream().filter(c -> c.getNo().equals(categoryNo)).findFirst().orElse(null);
+        List<CategoryDto> childCategories = categories.stream()
+                .filter(c -> !c.getNo().equals(categoryNo))
+                .map(CategoryDto::createDto).toList();
+        Page<ProductDto> productDtos = productRepository.findByCategoryNo(categoryNo, pageable)
+                .map(ProductDto::createDto);
+
+        Integer parentNo = currentCategory.getParentCategory() != null ?
+                currentCategory.getParentCategory().getNo() : null;
+        return new CategoryResult(currentCategory.getNo(), currentCategory.getName(), parentNo, childCategories, productDtos);
+    }
+
+//    @Transactional
+//    public CategoryResult getCategoryInfo(Integer categoryNo, Pageable pageable) {
+////        1. DB접근 횟수가 한 번 더 많지만 가독성이 좋음
+//        Category currentCategory = categoryRepository.findByNo(categoryNo)
+//                .orElseThrow(() -> new PageException(CustomErrorCode.NOT_FOUND));
+//        List<CategoryDto> childCategories = categoryRepository.findByParentCategory_No(categoryNo).stream()
+//                .map(CategoryDto::createDto).toList();
+//        Page<ProductDto> productDtos = productRepository.findByCategoryNo(categoryNo, pageable)
+//                .map(ProductDto::createDto);
+//
+//        Integer parentNo = currentCategory.getParentCategory() != null ?
+//                currentCategory.getParentCategory().getNo() : null;
+//        return new CategoryResult(currentCategory.getNo(), currentCategory.getName(), parentNo, childCategories, productDtos);
+//    }
+
+    // 상위 카테고리 번호로 하위 카테고리 조회
+    public List<CategoryDto> findSubcategories(Integer parentNo) {
+        return categoryRepository.findByParentCategory_No(parentNo).stream()
+                .map(CategoryDto::createDto).toList();
+    }
+}

--- a/src/main/java/com/jiho/anniehands/category/CategoryService.java
+++ b/src/main/java/com/jiho/anniehands/category/CategoryService.java
@@ -33,25 +33,26 @@ public class CategoryService {
     @Transactional
     public CategoryResult getCategoryInfo(Integer categoryNo, Pageable pageable) {
         // 2. 카테고리와 상품은 양방향 매핑으로 카테고리로 번호로 상품 조회가 가능하다.
-        // DB접근의 횟수가 적어짐 상대적으로 수행처리가 속도가 빠름
+        // 첫번째 방법에 비해 DB접근 횟수 1회 적어짐 상대적으로 수행처리가 속도가 빠름
         List<Category> categories = categoryRepository.findCategoriesAndSubcategoriesByNo(categoryNo);
         if (categories.isEmpty()) {
             throw new PageException(CustomErrorCode.NOT_FOUND);
         }
+        // categoryNo과 일치하는 것을 찾고 없으면 null을 반환
         Category currentCategory = categories.stream().filter(c -> c.getNo().equals(categoryNo)).findFirst().orElse(null);
+        // categoryNo을 제외하고 나머지 카테고리 맵핑, 부모 카테고리 요청일 경우 ParentCategory null 방지를 위함
         List<CategoryDto> childCategories = categories.stream()
                 .filter(c -> !c.getNo().equals(categoryNo))
                 .map(CategoryDto::createDto).toList();
         Page<ProductDto> productDtos = productRepository.findByCategoryNo(categoryNo, pageable)
                 .map(ProductDto::createDto);
-
         Integer parentNo = currentCategory.getParentCategory() != null ?
                 currentCategory.getParentCategory().getNo() : null;
         return new CategoryResult(currentCategory.getNo(), currentCategory.getName(), parentNo, childCategories, productDtos);
     }
 
 //    @Transactional
-//    public CategoryResult getCategoryInfo(Integer categoryNo, Pageable pageable) {
+//    public CategoryResult getCategorySecondInfo(Integer categoryNo, Pageable pageable) {
 ////        1. DB접근 횟수가 한 번 더 많지만 가독성이 좋음
 //        Category currentCategory = categoryRepository.findByNo(categoryNo)
 //                .orElseThrow(() -> new PageException(CustomErrorCode.NOT_FOUND));

--- a/src/main/java/com/jiho/anniehands/common/exception/CustomErrorCode.java
+++ b/src/main/java/com/jiho/anniehands/common/exception/CustomErrorCode.java
@@ -6,12 +6,12 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum CustomErrorCode {
-    // Enum 에러 코드 정의
     NO_MATCHING_MEMBER("400", "없는 회원입니다."),
     INVALID_VERIFICATION_CODE("400", "입력하신 인증번호가 일치하지 않습니다."),
     MISMATCHED_PASSWORD("400", "비밀번호가 일치하지 않습니다."),
     DUPLICATE_EMAIL("409", "이미 사용 중인 이메일입니다."),
-    DUPLICATE_USERNAME("409", "이미 사용 중인 아이디입니다.");
+    DUPLICATE_USERNAME("409", "이미 사용 중인 아이디입니다."),
+    NOT_FOUND("404", "페이지를 찾을 수 없습니다.");
 
     private final String code;
     private final String message;

--- a/src/main/java/com/jiho/anniehands/common/exception/ExceptionControllerAdvice.java
+++ b/src/main/java/com/jiho/anniehands/common/exception/ExceptionControllerAdvice.java
@@ -1,6 +1,5 @@
 package com.jiho.anniehands.common.exception;
 
-import com.jiho.anniehands.user.UserException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -27,6 +26,13 @@ public class ExceptionControllerAdvice {
         redirectAttributes.addFlashAttribute("errorMessage", ex.getMessage());
         // TODO: 문자열 하드코딩이 아닌, 다양한 요청 url로 리다이렉트 할 수 있도록 고민하기
         return "redirect:/user/signup";
+    }
+
+    // 잘못된 페이지 요청을 했을 때 예외 처리 핸들러
+    @ExceptionHandler(PageException.class)
+    public String pageExceptionHandler(PageException ex, RedirectAttributes redirectAttributes) {
+        redirectAttributes.addFlashAttribute("errorMessage", ex.getMessage());
+        return "redirect:/";
     }
 
 

--- a/src/main/java/com/jiho/anniehands/common/exception/PageException.java
+++ b/src/main/java/com/jiho/anniehands/common/exception/PageException.java
@@ -1,0 +1,7 @@
+package com.jiho.anniehands.common.exception;
+
+public class PageException extends AnnieHandsException {
+    public PageException(CustomErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/jiho/anniehands/common/exception/UserException.java
+++ b/src/main/java/com/jiho/anniehands/common/exception/UserException.java
@@ -1,7 +1,4 @@
-package com.jiho.anniehands.user;
-
-import com.jiho.anniehands.common.exception.AnnieHandsException;
-import com.jiho.anniehands.common.exception.CustomErrorCode;
+package com.jiho.anniehands.common.exception;
 
 public class UserException extends AnnieHandsException {
     public UserException(CustomErrorCode errorCode) {

--- a/src/main/java/com/jiho/anniehands/main/MainController.java
+++ b/src/main/java/com/jiho/anniehands/main/MainController.java
@@ -1,6 +1,7 @@
 package com.jiho.anniehands.main;
 
 import com.jiho.anniehands.product.Product;
+import com.jiho.anniehands.product.ProductDto;
 import com.jiho.anniehands.product.ProductService;
 import com.jiho.anniehands.security.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
@@ -22,7 +23,7 @@ public class MainController {
     @GetMapping("/")
     public String home(@AuthenticationPrincipal CustomUserDetails loginUser, Model model) {
         // TODO: 현재 인기상품은 더미 데이터 사용 중 적절한 인기 제품 기준 할당 후 뷰에 출력하기
-        List<Product> products = this.productService.getTop5NewProducts();
+        List<ProductDto> products = productService.getTop5NewProducts();
         model.addAttribute("products", products);
         if (loginUser != null) {
             log.info("현재 로그인된 유저 ====> {}", loginUser.toString());

--- a/src/main/java/com/jiho/anniehands/product/ProductController.java
+++ b/src/main/java/com/jiho/anniehands/product/ProductController.java
@@ -1,18 +1,56 @@
 package com.jiho.anniehands.product;
 
+import com.jiho.anniehands.category.CategoryDto;
+import com.jiho.anniehands.category.CategoryResult;
+import com.jiho.anniehands.category.CategoryService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 
+import java.util.List;
+
+@Slf4j
 @Controller
 @RequiredArgsConstructor
 @RequestMapping("product")
 public class ProductController {
 
+    private final ProductService productService;
+    private final CategoryService categoryService;
+
     @GetMapping("/list")
-    public String list(Model model) {
+    public String list(
+            @RequestParam(required = false) Integer categoryNo,
+            @PageableDefault(size = 20, page = 0, sort = "createdDate", direction = Sort.Direction.DESC) Pageable pageable,
+            Model model) {
+        CategoryResult categoryResult = categoryService.getCategoryInfo(categoryNo, pageable);
+        // 하위 카테고리를 조회했을 때 하위 카테고리 버튼을 유지하기 위해 상위 카테고리 번호로 하위 카테고리 조회
+        if (categoryResult.getParent() != null) {
+            List<CategoryDto> Children = categoryService.findSubcategories(categoryResult.getParent());
+            categoryResult.setChildren(Children);
+        }
+        prepareModel(pageable, model, categoryResult);
         return "page/product/list";
+    }
+
+    private void prepareModel(Pageable pageable, Model model, CategoryResult categoryResult) {
+        String sortString = pageable.getSort().toString().replace(": ", ",");
+        int currentPageNo = pageable.getPageNumber();
+        int totalPages = categoryResult.getProducts().getTotalPages();
+        int startPage = Math.max(0, currentPageNo - 2); // 현재 페이지에서 2 빼기
+        int endPage = Math.min(totalPages - 1, currentPageNo + 2); // 현재 페이지에서 2 더하기
+        model.addAttribute("sortString", sortString);
+        model.addAttribute("categoryResult", categoryResult);
+        model.addAttribute("pageable", pageable);
+        model.addAttribute("startPage", startPage);
+        model.addAttribute("endPage", endPage);
+        model.addAttribute("totalPages", totalPages);
     }
 }

--- a/src/main/java/com/jiho/anniehands/product/ProductDto.java
+++ b/src/main/java/com/jiho/anniehands/product/ProductDto.java
@@ -1,0 +1,27 @@
+package com.jiho.anniehands.product;
+
+import lombok.*;
+
+@Getter
+@Builder
+@ToString
+public class ProductDto {
+
+    private Long no;
+    private String name;
+    private String content;
+    private String thumbnailPath;
+    private Integer price;
+    private Integer sale;
+
+    public static ProductDto createDto(Product product) {
+        return ProductDto.builder()
+                .no(product.getNo())
+                .name(product.getName())
+                .content(product.getContent())
+                .thumbnailPath(product.getThumbnailPath())
+                .price(product.getPrice())
+                .sale(product.getSale())
+                .build();
+    }
+}

--- a/src/main/java/com/jiho/anniehands/product/ProductRepository.java
+++ b/src/main/java/com/jiho/anniehands/product/ProductRepository.java
@@ -1,14 +1,23 @@
 package com.jiho.anniehands.product;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
-public interface ProductRepository extends JpaRepository<Product,Integer> {
+public interface ProductRepository extends JpaRepository<Product,Long> {
 
     // 신상품 5개 조회
     List<Product> findTop5ByIsEnabledOrderByCreatedDateDesc(Boolean isEnabled);
 
     // 상품 하나 조회
     Product findByNo(Long no);
+
+    @Query("SELECT p FROM Product p WHERE p.category.no = :categoryNo OR p.category.parentCategory.no = :categoryNo AND p.isEnabled = true")
+    Page<Product> findByCategoryNo(@Param("categoryNo") Integer categoryNo, Pageable pageable);
+
 }
+

--- a/src/main/java/com/jiho/anniehands/product/ProductService.java
+++ b/src/main/java/com/jiho/anniehands/product/ProductService.java
@@ -17,8 +17,9 @@ public class ProductService {
     }
 
     // 신상품 5개 조회
-    public List<Product> getTop5NewProducts() {
-        return this.productRepository.findTop5ByIsEnabledOrderByCreatedDateDesc(true);
+    public List<ProductDto> getTop5NewProducts() {
+        return productRepository.findTop5ByIsEnabledOrderByCreatedDateDesc(true).stream()
+                .map(ProductDto::createDto).toList();
     }
 
 

--- a/src/main/java/com/jiho/anniehands/user/UserService.java
+++ b/src/main/java/com/jiho/anniehands/user/UserService.java
@@ -1,6 +1,7 @@
 package com.jiho.anniehands.user;
 
 import com.jiho.anniehands.common.exception.CustomErrorCode;
+import com.jiho.anniehands.common.exception.UserException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -37,7 +38,6 @@ public class UserService {
                 .build();
     }
 
-
     // 아이디 혹은 이메일 중복 검사
     private void validateDuplicateUser(User user) {
         userRepository.findById(user.getId()).ifPresent(u -> {
@@ -46,16 +46,6 @@ public class UserService {
         userRepository.findByEmail(user.getEmail()).ifPresent(u -> {
             throw new UserException(CustomErrorCode.DUPLICATE_EMAIL);
         });
-    }
-
-    public User findByEmail(String email) {
-        return userRepository.findByEmail(email)
-                .orElseThrow(() -> new UserException(CustomErrorCode.NO_MATCHING_MEMBER));
-    }
-
-    public User findById(String id) {
-        return userRepository.findById(id)
-                .orElseThrow(() -> new UserException(CustomErrorCode.NO_MATCHING_MEMBER.getMessage()));
     }
 
 }

--- a/src/main/resources/static/css/page/main/home.css
+++ b/src/main/resources/static/css/page/main/home.css
@@ -17,8 +17,8 @@
     justify-content: space-evenly;
 }
 .category-container a {
-    width: 100px;
-    height: 100px;
+    width: 150px;
+    height: 150px;
     border: 1px solid #d6d6d6;
     border-radius: 50%;
     background-color: #f8f9fe;

--- a/src/main/resources/static/js/page/product/list.js
+++ b/src/main/resources/static/js/page/product/list.js
@@ -1,0 +1,10 @@
+function changeSortOrder(sortValue) {
+    var params = new URLSearchParams(window.location.search);
+    var sortParams = sortValue.split(' '); // 공백으로 분리
+    if (sortParams.length === 2) {
+        var sortField = sortParams[0];
+        var sortDirection = sortParams[1].toUpperCase(); // 'asc' 또는 'desc'로 변경
+        params.set('sort', sortField + ',' + sortDirection);
+    }
+    window.location.search = params.toString();
+}

--- a/src/main/resources/templates/common/navbar.html
+++ b/src/main/resources/templates/common/navbar.html
@@ -44,18 +44,6 @@
                             <a class="nav-link" th:href="@{/logout}">로그아웃</a>
                         </li>
                     </ul>
-                    <ul class="navbar-nav">
-                        <li class="nav-item dropdown">
-                            <a aria-expanded="false" class="nav-link dropdown-toggle" data-bs-toggle="dropdown" href="#"
-                               id="navbarDropdownMenuLink" role="button">
-                                게시판
-                            </a>
-                            <ul aria-labelledby="navbarDropdownMenuLink" class="dropdown-menu">
-                                <li><a class="dropdown-item" href="#">실종</a></li>
-                                <li><a class="dropdown-item" href="#">입양</a></li>
-                            </ul>
-                        </li>
-                    </ul>
                 </div>
             </div>
         </nav>

--- a/src/main/resources/templates/layout/common-base.html
+++ b/src/main/resources/templates/layout/common-base.html
@@ -21,7 +21,7 @@
             font-family: 'TheJamsil5Bold', sans-serif;
         }
 
-        h1,h2,h3,label {
+        h1,h2,h3,h4 {
             font-family: 'TheJamsil5Bold', sans-serif;
         }
     </style>

--- a/src/main/resources/templates/page/main/home.html
+++ b/src/main/resources/templates/page/main/home.html
@@ -4,7 +4,18 @@
 <!-- 고유 CSS -->
 <head>
     <link rel="stylesheet" type="text/css" th:href="@{/css/page/main/home.css}">
+    <script th:inline="javascript">
+        /*<![CDATA[*/
+        var errorMessage = [[${errorMessage}]];
+        if(errorMessage) {
+            window.onload = function() {
+                alert(errorMessage);
+            };
+        }
+        /*]]>*/
+    </script>
 </head>
+
 <!-- 고유 content -->
 
 <!-- 슬라이드 시작 -->
@@ -36,51 +47,37 @@
     <div class="product-category">
         <div class="category-container py-3">
             <div class="category-item item">
-                <a class="text-black text-decoration-none" href="/product/list" >
+                <a class="text-black text-decoration-none" th:href="@{/product/list?categoryNo=}" >
                     <strong>
-                        <span>베스트</span>
+                        <h4 class="mt-2">베스트</h4>
                     </strong>
                 </a>
             </div>
             <div class="category-item item">
-                <a class="text-black text-decoration-none" href="/product/list">
+                <a class="text-black text-decoration-none" th:href="@{/product/list?categoryNo=100}">
                     <strong>
-                        <span>강아지</span>
+                        <h4 class="mt-2">강아지</h4>
                     </strong>
                 </a>
             </div>
             <div class="category-item item">
-                <a class="text-black text-decoration-none" href="/product/list">
+                <a class="text-black text-decoration-none" th:href="@{/product/list?categoryNo=200}">
                     <strong>
-                        <span>고양이</span>
+                        <h4 class="mt-2">고양이</h4>
                     </strong>
                 </a>
             </div>
             <div class="category-item item">
-                <a class="text-black text-decoration-none" href="/product/list">
+                <a class="text-black text-decoration-none" th:href="@{/product/list?categoryNo=}">
                     <strong>
-                        <span>주식</span>
+                        <h4 class="mt-2">실종게시판</h4>
                     </strong>
                 </a>
             </div>
             <div class="category-item item">
-                <a class="text-black text-decoration-none" href="/product/list">
+                <a class="text-black text-decoration-none" th:href="@{/product/list?categoryNo=}">
                     <strong>
-                        <span>간식</span>
-                    </strong>
-                </a>
-            </div>
-            <div class="category-item item">
-                <a class="text-black text-decoration-none" href="/product/list">
-                    <strong>
-                        <span>건강보조제</span>
-                    </strong>
-                </a>
-            </div>
-            <div class="category-item item">
-                <a class="text-black text-decoration-none" href="/product/list">
-                    <strong>
-                        <span>패션</span>
+                        <h4 class="mt-2">입양게시판</h4>
                     </strong>
                 </a>
             </div>

--- a/src/main/resources/templates/page/product/list.html
+++ b/src/main/resources/templates/page/product/list.html
@@ -7,103 +7,48 @@
 </head>
 <!-- 고유 content -->
 <div class="container" layout:fragment="content-top">
-    <h3 class="my-3">강아지</h3>
+    <h3 th:text="${categoryResult.name}" class="my-3">강아지</h3>
     <div class="card">
         <div class="card-header">
             <div class="d-flex justify-content-between">
                 <ul class="nav nav-pills card-header-pills">
-                    <li class="nav-item">
-                        <a class="nav-link active" href="#">주식</a>
-                    </li>
-                    <li class="nav-item">
-                        <a class="nav-link" href="#">간식</a>
-                    </li>
-                    <li class="nav-item">
-                        <a class="nav-link" href="#">건강보조제</a>
-                    </li>
-                    <li class="nav-item">
-                        <a class="nav-link" href="#">패션</a>
-                    </li>
+                    <div th:each="children : ${categoryResult.children}">
+                        <li class="nav-item">
+                            <a class="nav-link" th:href="@{/product/list(categoryNo=${children.no})}" th:text="${children.name}">하위 카테고리 이름</a>
+                        </li>
+                    </div>
                 </ul>
                 <div class="d-flex">
-                    <select class="form-select me-3" name="sort" style="width: 150px;">
-                        <option value="latest">신상품
+                    <select onchange="changeSortOrder(this.value)" class="form-select me-3" name="sort"
+                            style="width: 150px;">
+                        <option value="createdDate DESC"
+                                th:selected="${sort == 'createdDate' && direction == 'DESC'}">신상품순
                         </option>
-                        <option value="oldest">낮은 가격
+                        <option value="sale ASC" th:selected="${sort == 'sale' && direction == 'ASC'}">낮은 가격순
                         </option>
-                        <option value="popular">높은 가격
-                        </option>
-                        <option value="popular">인기 상품
+                        <option value="sale DESC" th:selected="${sort == 'sale' && direction == 'DESC'}">높은 가격순
                         </option>
                     </select>
                 </div>
             </div>
         </div>
     </div>
-    <!-- 인기 상품 -->
+
     <div class="best-container my-3">
         <div class="row row-custom">
-            <div class="col-auto product-item mb-5">
+            <div class="col-auto product-item mb-5" th:each="product : ${categoryResult.products}">
                 <div class="card">
-                    <img alt="상품 이미지" class="card-img-top" src="/images/home-image1.jpg">
-                    <div class="card-body">
-                        <h5 class="card-title separator">강아지 패딩</h5>
-                        <p class="card-text">37,000</p>
-                    </div>
-                </div>
-            </div>
-            <div class="col-auto product-item mb-5">
-                <div class="card">
-                    <img alt="상품 이미지" class="card-img-top" src="/images/home-image1.jpg">
-                    <div class="card-body">
-                        <h5 class="card-title">캣잎</h5>
-                        <p class="card-text price">13,000</p>
-                    </div>
-                </div>
-            </div>
-            <div class="col-auto product-item mb-5">
-                <div class="card">
-                    <img alt="상품 이미지" class="card-img-top" src="/images/home-image1.jpg">
-                    <div class="card-body">
-                        <h5 class="card-title">캣잎</h5>
-                        <p class="card-text">13,000</p>
-                    </div>
-                </div>
-            </div>
-            <div class="col-auto product-item mb-5">
-                <div class="card">
-                    <img alt="상품 이미지" class="card-img-top" src="/images/home-image1.jpg">
-                    <div class="card-body">
-                        <h5 class="card-title">츄르 1box</h5>
-                        <p class="card-text">28,000</p>
-                    </div>
-                </div>
-            </div>
-            <div class="col-auto product-item mb-5">
-                <div class="card">
-                    <img alt="상품 이미지" class="card-img-top" src="/images/home-image1.jpg">
-                    <div class="card-body">
-                        <h5 class="card-title">츄르 1box</h5>
-                        <p class="card-text">28,000</p>
-                    </div>
-                </div>
-            </div>
-            <div class="col-auto product-item mb-5">
-                <div class="card">
-                    <img alt="상품 이미지" class="card-img-top" src="/images/home-image1.jpg">
-                    <div class="card-body">
-                        <h5 class="card-title">츄르 1box</h5>
-                        <p class="card-text">28,000</p>
-                    </div>
-                </div>
-            </div>
-            <div class="col-auto product-item mb-5">
-                <div class="card">
-                    <img alt="상품 이미지" class="card-img-top" src="/images/home-image1.jpg">
-                    <div class="card-body">
-                        <h5 class="card-title">츄르 1box</h5>
-                        <p class="card-text">28,000</p>
-                    </div>
+                    <img alt="상품 이미지" class="card-img-top" th:src="${product.thumbnailPath}">
+                    <h5 class="card-title" th:text="${product.name}">상품명</h5>
+                    <p class="card-text">
+                        <span th:if="${product.sale < product.price}" style="text-decoration: line-through;"
+                              th:text="${#numbers.formatInteger(product.price, 0, 'COMMA')} + '원'">가격</span>
+                        <span th:if="${product.sale < product.price}" class="fw-bold"
+                              style="color: red; margin-left: 10px;"
+                              th:text="${#numbers.formatInteger(product.sale, 0, 'COMMA')} + '원'">세일 가격</span>
+                        <span th:unless="${product.sale < product.price}"
+                              th:text="${#numbers.formatInteger(product.price, 0, 'COMMA')} + '원'">가격</span>
+                    </p>
                 </div>
             </div>
         </div>
@@ -113,28 +58,14 @@
             <div>
                 <ul class="pagination justify-content-center">
                     <li class="page-item">
-                        <a class="page-link" href="#"><i
+                        <a class="page-link" th:href="@{/product/list(categoryNo=${categoryResult.no}, page=0, size=${pageable.pageSize}, sort=${sortString})}"><i
                                 class="fa-solid fa-angles-left"></i></a>
                     </li>
-                    <li class="page-item">
-                        <a class="page-link" href="#"><i
-                                class="fa-solid fa-chevron-left"></i></a>
+                    <li th:each="pageNum : ${#numbers.sequence(startPage, endPage)}" th:classappend="${pageable.pageNumber == pageNum} ? 'active' : ''"class="page-item">
+                        <a th:href="@{/product/list(categoryNo=${categoryResult.no}, page=${pageNum}, size=${pageable.pageSize}, sort=${sortString})}" class="page-link" th:text="${pageNum + 1}"></a>
                     </li>
                     <li class="page-item">
-                        <a class="page-link" href="#">1</a>
-                    </li>
-                    <li class="page-item">
-                        <a class="page-link" href="#">2</a>
-                    </li>
-                    <li class="page-item">
-                        <a class="page-link" href="#">3</a>
-                    </li>
-                    <li class="page-item">
-                        <a class="page-link" href="#"><i
-                                class="fa-solid fa-chevron-right"></i></a>
-                    </li>
-                    <li class="page-item">
-                        <a class="page-link" href="#"><i
+                        <a class="page-link" th:href="@{/product/list(categoryNo=${categoryResult.no}, page=${totalPages - 1}, size=${pageable.pageSize}, sort=${sortString})}"><i
                                 class="fa-solid fa-angles-right"></i></a>
                     </li>
                 </ul>
@@ -150,6 +81,7 @@
     </div>
     <!-- 고유 script -->
     <th:block layout:fragment="script">
-        <script></script>
+        <script th:src="@{/js/page/product/list.js}"></script>
     </th:block>
+</div>
 </html>

--- a/src/main/resources/templates/page/product/list.html
+++ b/src/main/resources/templates/page/product/list.html
@@ -36,6 +36,9 @@
 
     <div class="best-container my-3">
         <div class="row row-custom">
+            <div th:if="${#lists.isEmpty(categoryResult.products.content)}" class="col-12 text-center">
+                <h4 colspan="5" class="text-center">현재 상품이 존재하지 않습니다.</h4>
+            </div>
             <div class="col-auto product-item mb-5" th:each="product : ${categoryResult.products}">
                 <div class="card">
                     <img alt="상품 이미지" class="card-img-top" th:src="${product.thumbnailPath}">
@@ -61,7 +64,7 @@
                         <a class="page-link" th:href="@{/product/list(categoryNo=${categoryResult.no}, page=0, size=${pageable.pageSize}, sort=${sortString})}"><i
                                 class="fa-solid fa-angles-left"></i></a>
                     </li>
-                    <li th:each="pageNum : ${#numbers.sequence(startPage, endPage)}" th:classappend="${pageable.pageNumber == pageNum} ? 'active' : ''"class="page-item">
+                    <li th:if="${totalPages > 0}" th:each="pageNum : ${#numbers.sequence(startPage, endPage)}" th:classappend="${pageable.pageNumber == pageNum} ? 'active' : ''"class="page-item">
                         <a th:href="@{/product/list(categoryNo=${categoryResult.no}, page=${pageNum}, size=${pageable.pageSize}, sort=${sortString})}" class="page-link" th:text="${pageNum + 1}"></a>
                     </li>
                     <li class="page-item">

--- a/src/main/resources/templates/page/user/login.html
+++ b/src/main/resources/templates/page/user/login.html
@@ -7,6 +7,7 @@
 </head>
 <!-- 고유 content -->
 <div class="container" layout:fragment="content-top">
+    <!-- 길이가 짧아서 다른 페이지보다 약간 차이날 수 있음-->
     <div class="card">
         <div class="card-header  py-1 pt-2 text-center">
             <h3>로그인</h3>

--- a/src/test/java/com/jiho/anniehands/AnniehandsApplicationTests.java
+++ b/src/test/java/com/jiho/anniehands/AnniehandsApplicationTests.java
@@ -2,6 +2,7 @@ package com.jiho.anniehands;
 
 import com.jiho.anniehands.common.exception.CustomErrorCode;
 import com.jiho.anniehands.product.Product;
+import com.jiho.anniehands.product.ProductDto;
 import com.jiho.anniehands.product.ProductService;
 import com.jiho.anniehands.user.Role;
 import com.jiho.anniehands.user.UserRepository;
@@ -31,7 +32,7 @@ class AnniehandsApplicationTests {
 
 	@Test
 	void get5NewProducts() {
-		List<Product> products = productService.getTop5NewProducts();
+		List<ProductDto> products = productService.getTop5NewProducts();
 		assertThat(products).hasSize(5);
 	}
 

--- a/src/test/java/com/jiho/anniehands/category/CategoryServiceTest.java
+++ b/src/test/java/com/jiho/anniehands/category/CategoryServiceTest.java
@@ -22,10 +22,7 @@ class CategoryServiceTest {
 //        categoryService.getCategoryInfo(categoryNo, pageable);
 //        long endTime = System.currentTimeMillis();
 //        System.out.println("First Method Execution Time: " + (endTime - startTime) + " ms");
-//
-//
 //    }
-
 
 //    @Test
 //    public void testGetCategoryInfoSecondMethod() {
@@ -38,8 +35,5 @@ class CategoryServiceTest {
 //        long endTime = System.currentTimeMillis();
 //        System.out.println("Second Method Execution Time: " + (endTime - startTime) + " ms");
 //    }
-//
-
-
 
 }

--- a/src/test/java/com/jiho/anniehands/category/CategoryServiceTest.java
+++ b/src/test/java/com/jiho/anniehands/category/CategoryServiceTest.java
@@ -1,0 +1,45 @@
+package com.jiho.anniehands.category;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+@SpringBootTest
+class CategoryServiceTest {
+
+    @Autowired
+    private CategoryService categoryService;
+
+//    @Test
+//    public void testGetCategoryInfoFirstMethod() {
+//        Integer categoryNo = 100; // 테스트용 카테고리 번호
+//        Pageable pageable = PageRequest.of(0, 20);
+//
+//        // 첫 번째 방법 테스트
+//        long startTime = System.currentTimeMillis();
+//        categoryService.getCategoryInfo(categoryNo, pageable);
+//        long endTime = System.currentTimeMillis();
+//        System.out.println("First Method Execution Time: " + (endTime - startTime) + " ms");
+//
+//
+//    }
+
+
+//    @Test
+//    public void testGetCategoryInfoSecondMethod() {
+//        Integer categoryNo = 100; // 테스트용 카테고리 번호
+//        Pageable pageable = PageRequest.of(0, 20);
+//
+//        // 두 번째 방법 테스트
+//        long startTime = System.currentTimeMillis();
+//        categoryService.getCategorySecondInfo(categoryNo, pageable);
+//        long endTime = System.currentTimeMillis();
+//        System.out.println("Second Method Execution Time: " + (endTime - startTime) + " ms");
+//    }
+//
+
+
+
+}


### PR DESCRIPTION
## ✅ PR 내용
- JPA를 이용하여 상품의 상위 및 하위 카테고리에 따른 상품 출력 기능을 구현한다.
- 상위 카테고리를 선택하면 해당 카테고리에 속하는 모든 하위 카테고리의 상품을 표시한다.
- 하위 카테고리를 선택하면 해당 카테고리에만 속하는 상품을 표시한다.
- 페이지 버튼은 현재 페이지 기준 전 후로 2개씩 표기한다.
  - 만약 현재 페이지가 3일 경우 1 2 (3) 4 5 식으로 표현된다.
  - 맨 앞 페이지/맨 뒤 페이지로 이동 벼튼을 구현했다. 
## 🔍 참고사항
- `Category` 및 `Product` 엔티티를 기반으로 하는 DTO 클래스(CategoryDto, ProductDto)를 구현하여 데이터 전달과 표시를 최적화했다.
- `CategoryService`와 `ProductService`에서 비즈니스 로직을 처리하고, 컨트롤러에서는 이를 활용해 뷰에 데이터를 전달한다.
- 성능 테스트를 통해 `CategoryService`의 두 가지 메서드(`getCategoryInfo`, `getCategorySecondInfo`)를 비교했다. 테스트 결과, 더 빠른 실행 시간을 보인 메서드를 서비스 로직에 채택했다.
- `Pageable` 인터페이스를 사용하여 상품 목록의 페이징 처리를 구현했다.